### PR TITLE
(tool) Add run-sequence to clean up before build/serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "devDependencies": {
     "browser-sync": "^2.7.13",
     "coffee-script": "^1.9.3",
-    "del": "^1.2.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-cache": "^0.2.10",
@@ -34,6 +33,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-useref": "^1.2.0",
     "main-bower-files": "^2.8.2",
+    "run-sequence": "^1.1.1",
     "shelljs": "^0.5.1",
     "wiredep": "^2.2.2"
   }


### PR DESCRIPTION
## Related task

[Limpiar directorios temporales al hacer build o serve (97158)](http://manoderecha.net/md/index.php/task/97158)
## Problem

`gulp build` and `gulp serve` don't run the `clean` task (it has to be done manually). This can cause issues such as an old, outdated, renamed article still appearing in the final build (or the browsersync server) even though its source markdown file in `app` is gone, since the `.staging` directory is never automatically cleaned.
## Solution

`run-sequence` is installed and used to force run the `clean` task before the rest of the tasks on which `build` and `serve` depend on. This ensures that any jekyll rebuild will be done from a freshly clean `.staging` directory.
## Tests

Tested with `gulp build` and `gulp serve` to make sure that all relevant directories are cleaned.
