### PR TITLE
(tool) Fix images not being output to dist on gulp build

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -6,6 +6,7 @@ $           = require('gulp-load-plugins')()
 wiredep     = require('wiredep').stream
 shell       = require 'shelljs'
 runSequence = require 'run-sequence'
+del         = require 'del'
 
 reload = browserSync.reload
 
@@ -70,7 +71,7 @@ gulp.task 'moveFiles', ['scripts', 'styles'], ->
     'app/_posts/**/*'
     'app/_includes/**/*'
     'app/p/**/*' # Pagination template
-    'app/images/**/*'
+    # 'app/images/**/*'
     'app/fonts/**/*'
   ]
 
@@ -134,30 +135,25 @@ gulp.task 'extras', ->
 gulp.task 'clean', ->
   # Clean staging, tmp and _site dirs
   # Only really necessary for build
-  gulp.src [
+  del [
     '.staging'
     '.tmp'
     'dist/**/*'
     'dist/.*'
-    '!dist/.git'
-  ],
-    dot: true
-  .pipe $.clean()
+  ]
 
 gulp.task 'cleanStray', ->
   # Removes stray files from staging after useref is done with them
-  gulp.src [
+  del [
     '.staging/_includes/scripts'
     '.staging/_includes/styles'
-  ],
-    dot: true
-  .pipe $.clean()
+  ]
 
 # Basic entry point
-gulp.task 'build', ->
+gulp.task 'build', ['clean'], ->
   # Clean first, then the rest
-  runSequence 'clean',
-    ['jekyll', 'images', 'fonts', 'extras'],
+  runSequence ['jekyll', 'fonts', 'extras'],
+    'images',
     ['cleanStray', 'size']
 
 gulp.task 'size', ->
@@ -165,9 +161,9 @@ gulp.task 'size', ->
   gulp.src 'dist/**/*'
     .pipe $.size {title: 'build', gzip: true}
 
-gulp.task 'serve', ->
+gulp.task 'serve', ['clean'], ->
   # Clean first, then the rest
-  runSequence 'clean', ['jekyll:tmp', 'fonts'], 'browsersync'
+  runSequence ['jekyll:tmp', 'fonts'], 'browsersync'
 
 gulp.task 'browsersync', ->
   # Run the web server
@@ -224,7 +220,8 @@ gulp.task 'deploy', ['build'], ->
   # Deploy to Github Pages
   gulp.src 'dist'
     .pipe $.subtree()
-    .pipe $.clean()
+
+  del ['dist']
 
 # Default task
 gulp.task 'default', ['build']

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "devDependencies": {
     "browser-sync": "^2.7.13",
     "coffee-script": "^1.9.3",
+    "del": "^1.2.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-cache": "^0.2.10",
-    "gulp-clean": "^0.3.1",
     "gulp-coffee": "^2.3.1",
     "gulp-debug": "^2.0.1",
     "gulp-exec": "^2.1.1",


### PR DESCRIPTION
## Related task

[Imágenes de posts no se están viendo (97841)](http://manoderecha.net/md/index.php/task/97841)

## Problem

`gulp build` is placing the images into `dist/images` correctly, but jekyll deletes them afterwards. This causes the final build to lack the directory, and therefore no local images can be used (images from external posts are still fine)

## Solution

The tasks are rearranged to ensure that jekyll runs before the image optimization step, which then places the images where they belong

## Tests

Tested by running `gulp build` to verify that the images task runs after the jekyll task, and that the `images` dir is present and contains the actual images.